### PR TITLE
Update SQL dependency version to enable compiler validation for time module constructs

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -13,7 +13,7 @@ distribution = "2201.0.1"
 path = "../native/build/libs/mssql-native-1.4.0-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/sql-native-1.4.0-20220510-120200-dbad37d.jar"
+path = "./lib/sql-native-1.4.0-20220512-122900-5e90b1c.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/mssql-jdbc-9.2.0.jre11.jar"

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [Improve API documentation to reflect query usages](https://github.com/ballerina-platform/ballerina-standard-library/issues/2524)
+- [Fixed compiler plugin validation for `time` module constructs](https://github.com/ballerina-platform/ballerina-standard-library/issues/2893)
 
 ## [1.3.0] - 2022-01-29
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ ballerinaGradlePluginVersion=0.14.1
 
 ballerinaLangVersion=2201.0.1
 
-stdlibSqlVersion=1.4.0-20220510-120200-dbad37d
+stdlibSqlVersion=1.4.0-20220512-122900-5e90b1c
 
 stdlibIoVersion=1.2.1
 stdlibRegexVersion=1.2.1


### PR DESCRIPTION
## Purpose
$subject 

Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/2893

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
