### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration
     secrets: inherit 
     with:
       additional-windows-test-flags: "-x test"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,24 +1,24 @@
 [package]
 org = "ballerinax"
 name = "mssql"
-version = "1.18.0"
+version = "1.18.1"
 authors = ["Ballerina"]
 keywords = ["Client", "Network", "SQL", "RDBMS", "SQLServer", "MSSQL", "Vendor/Microsoft", "Area/Database", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-mssql"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "mssql-native"
-version = "1.18.0"
-path = "../native/build/libs/mssql-native-1.18.0.jar"
+version = "1.18.1"
+path = "../native/build/libs/mssql-native-1.18.1-SNAPSHOT.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "sql-native"
 version = "1.19.0"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["Client", "Network", "SQL", "RDBMS", "SQLServer", "MSSQL", "Vendor/M
 repository = "https://github.com/ballerina-platform/module-ballerinax-mssql"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-20260527-050400-74f7e6bf"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "mssql-compiler-plugin"
 class = "io.ballerina.stdlib.mssql.compiler.MSSQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/mssql-compiler-plugin-1.18.0.jar"
+path = "../compiler-plugin/build/libs/mssql-compiler-plugin-1.18.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.14.0-20260527-050400-74f7e6bf"
 
 [[package]]
 org = "ballerina"
@@ -421,7 +421,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mssql"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -80,7 +80,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.0"
+version = "2.16.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -317,7 +317,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,9 +16,55 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        // Remove flag removed in Java 25
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        // Inject JAVA_HOME so the bal script picks up Java 25
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 buildscript {
     repositories {
+        mavenLocal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/plugin-gradle'
             credentials {
@@ -87,8 +133,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"
@@ -117,17 +164,22 @@ publishing {
     }
 }
 
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
+}
+
 tasks.register('startMSSQLServers') {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
         def stdOut = new ByteArrayOutputStream()
         def cmd = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] : ['sh', '-c']
-        exec {
+        execHelper.execOperations.exec {
             commandLine cmd + ["docker compose -f tests/resources/compose.yaml ps --services --filter status=running"]
             standardOutput = stdOut
         }
         if (stdOut.toString().trim().isEmpty()) {
             println "Starting MSSQL server."
-            exec {
+            execHelper.execOperations.exec {
                 commandLine cmd + ["docker compose -f tests/resources/compose.yaml up -d"]
             }
             // Wait for containers to be healthy
@@ -135,7 +187,7 @@ tasks.register('startMSSQLServers') {
             int retries = 18 // 90 seconds max, 5s interval
             for (int i = 0; i < retries; i++) {
                 def healthOut = new ByteArrayOutputStream()
-                exec {
+                execHelper.execOperations.exec {
                     commandLine cmd + ["docker compose -f tests/resources/compose.yaml ps --format '{{.Name}}: {{.Health}}'"]
                     standardOutput = healthOut
                     ignoreExitValue = true
@@ -158,16 +210,17 @@ tasks.register('startMSSQLServers') {
 }
 
 tasks.register('stopMSSQLServers') {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
         def stdOut = new ByteArrayOutputStream()
         def cmd = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] : ['sh', '-c']
-        exec {
+        execHelper.execOperations.exec {
             commandLine cmd + ["docker compose -f tests/resources/compose.yaml ps --services --filter status=running"]
             standardOutput = stdOut
         }
         if (!stdOut.toString().trim().isEmpty()) {
             println "Stopping MSSQL server."
-            exec {
+            execHelper.execOperations.exec {
                 commandLine cmd + ["docker compose -f tests/resources/compose.yaml rm -svf"]
                 standardOutput = stdOut
             }
@@ -184,9 +237,13 @@ updateTomlFiles.dependsOn copyStdlibs
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
 build.dependsOn ":${packageName}-compiler-plugin:build"
+build.dependsOn patchBallerinaScripts
 
 test.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-compiler-plugin:build"
 test.dependsOn ":${packageName}-native:build"
 test.dependsOn "startMSSQLServers"
+test.dependsOn patchBallerinaScripts
 test.finalizedBy "stopMSSQLServers"
+
+copyStdlibs.dependsOn patchBallerinaScripts

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -166,6 +166,9 @@ publishing {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 tasks.register('startMSSQLServers') {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -167,8 +167,6 @@ publishing {
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
     outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
-    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
-    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 tasks.register('startMSSQLServers') {

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,18 +7,18 @@ keywords = ["Client", "Network", "SQL", "RDBMS", "SQLServer", "MSSQL", "Vendor/M
 repository = "https://github.com/ballerina-platform/module-ballerinax-mssql"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.14.0-20260527-050400-74f7e6bf"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "mssql-native"
 version = "@toml.version@"
 path = "../native/build/libs/mssql-native-@project.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "sql-native"
 version = "@sql.version@"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["Client", "Network", "SQL", "RDBMS", "SQLServer", "MSSQL", "Vendor/M
 repository = "https://github.com/ballerina-platform/module-ballerinax-mssql"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-20260527-050400-74f7e6bf"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/build-config/spotbugs-exclude.xml
+++ b/build-config/spotbugs-exclude.xml
@@ -24,4 +24,14 @@
         <Class name="io.ballerina.stdlib.mssql.parameterprocessor.MssqlStatementParameterProcessor"/>
         <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
     </Match>
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
 </FindBugsFilter>

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ allprojects {
     version = project.version
 
     apply plugin: 'jacoco'
+jacoco {
+    toolVersion = jacocoVersion
+}
     apply plugin: 'maven-publish'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,14 @@ subprojects {
         jbalTools
     }
 
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
+
     dependencies {
         jbalTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
             transitive = false
@@ -125,7 +133,7 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn("${packageName}-native:build")
     dependsOn("${packageName}-compiler-plugin:build")
     dependsOn("${packageName}-ballerina:build")

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     checkstyle project(':checkstyle')
     checkstyle "com.puppycrawl.tools:checkstyle:${checkstylePluginVersion}"
 
-    jacocoRuntime "org.jacoco:org.jacoco.agent:0.8.6:runtime"
+    jacocoRuntime "org.jacoco:org.jacoco.agent:${jacocoVersion}:runtime"
 
     implementation project(':mssql-compiler-plugin')
 
@@ -47,8 +47,6 @@ dependencies {
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
-
-sourceCompatibility = JavaVersion.VERSION_21
 
 test {
     systemProperty "ballerina.offline.flag", "true"
@@ -85,13 +83,13 @@ spotbugsTest {
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
     ignoreFailures = true
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -52,10 +52,10 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,4 +1,6 @@
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
 /*
  * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
@@ -17,6 +19,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
  * specific language governing permissions and limitations
  * under the License.
  */
+
+abstract class ExamplesExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 apply plugin: 'java'
 
@@ -44,6 +50,7 @@ task updateTomlFiles {
 }
 
 task buildExamples {
+    def execHelper = project.objects.newInstance(ExamplesExecHelper)
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":java.jdbc-examples:test")) {
             buildExamples.enabled = false
@@ -52,7 +59,7 @@ task buildExamples {
     doLast {
         examples.each { example ->
             try {
-                exec {
+                execHelper.execOperations.exec {
                     workingDir "${project.projectDir}/${example}"
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                         commandLine 'cmd', '/c', "${ballerinaDist}/bin/bal.bat pack --offline && exit %%ERRORLEVEL%%"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.ballerina.stdlib
 version=1.18.1-SNAPSHOT
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
 
 checkstylePluginVersion=10.12.1
 spotbugsPluginVersion=6.5.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,14 @@
 group=io.ballerina.stdlib
 version=1.18.1-SNAPSHOT
-ballerinaLangVersion=2201.13.0
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 checkstylePluginVersion=10.12.1
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 downloadPluginVersion=5.4.0
 shadowJarPluginVersion=8.1.1
-releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
+jacocoVersion=0.8.13
 
 msSQLDriverVersion=12.8.1.jre11
 testngVersion=7.6.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.ballerina.stdlib
 version=1.18.1-SNAPSHOT
-ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 checkstylePluginVersion=10.12.1
 spotbugsPluginVersion=6.5.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -66,3 +66,4 @@ stdlibMssqlDriverVersion=1.7.0
 stdlibConfluentAvroSerDesVersion=1.0.2
 stdlibConfluentSchemaRegistryVersion=0.4.3
 stdlibKafkaVersion=4.6.3
+jacocoVersion=0.8.14

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,4 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -43,10 +43,8 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-
 jacoco {
-    toolVersion = "0.8.6"
+    toolVersion = "${jacocoVersion}"
 }
 
 test {
@@ -58,7 +56,7 @@ test {
     }
     jacoco {
         enabled = true
-        destinationFile = file("$buildDir/coverage-reports/jacoco.exec")
+        destinationFile = layout.buildDirectory.file("coverage-reports/jacoco.exec").get().asFile
         includeNoLocationClasses = true
     }
 }
@@ -70,13 +68,13 @@ spotbugsMain {
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
     ignoreFailures = true
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ pluginManagement {
     }
 
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -29,7 +30,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'ballerina-mssql'
@@ -48,9 +49,9 @@ project(':mssql-ballerina').projectDir = file('ballerina')
 project(':mssql-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':mssql-examples').projectDir = file('examples')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-20260527-050400-74f7e6bf`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack; wire `test.dependsOn patchBallerinaScripts` to ensure patching during split CI builds
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+); add exclusions for `THROWS`, `AT`, and `USELESS_STRING` detectors introduced in SpotBugs 4.9.x
- **JaCoCo 0.8.13**: Upgrade for Java 25 class file instrumentation support
- **CI workflow**: Update to `pull-request-build-template.yml@java-25-migration` for JDK 25 runner support

## Test plan
- [ ] `./gradlew build` passes green locally (full build including tests)
- [ ] `.bala` artifact is created as `*-java25-*.bala`
- [ ] SpotBugs passes on native module and compiler-plugin-tests
- [ ] CI passes on both Ubuntu and Windows