### PR TITLE
Bump ballerinax/cdc dependency to 1.3.2

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "mssql"
-version = "1.18.0"
+version = "1.18.1"
 authors = ["Ballerina"]
 keywords = ["Client", "Network", "SQL", "RDBMS", "SQLServer", "MSSQL", "Vendor/Microsoft", "Area/Database", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-mssql"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "mssql-native"
-version = "1.18.0"
-path = "../native/build/libs/mssql-native-1.18.0.jar"
+version = "1.18.1"
+path = "../native/build/libs/mssql-native-1.18.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "mssql-compiler-plugin"
 class = "io.ballerina.stdlib.mssql.compiler.MSSQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/mssql-compiler-plugin-1.18.0.jar"
+path = "../compiler-plugin/build/libs/mssql-compiler-plugin-1.18.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -80,7 +80,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.3"
+version = "2.16.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.2"
+version = "2.12.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -317,7 +317,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.2"
+version = "2.11.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -421,7 +421,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mssql"
-version = "1.18.1"
+version = "1.18.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -80,7 +80,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.0"
+version = "2.16.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -317,7 +317,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -405,7 +405,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.0"
+version = "1.3.2"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -421,7 +421,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mssql"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ stdlibFileVersion=1.12.0
 observeVersion=1.7.1
 observeInternalVersion=1.5.0
 
-stdlibCdcVersion=1.3.0
+stdlibCdcVersion=1.3.2
 stdlibMSSQLCdcDriverVersion=1.0.2
 
 # Transitive Dependencies


### PR DESCRIPTION
## Purpose

Bumps the `ballerinax/cdc` dependency from **1.3.0 → 1.3.2**.

cdc 1.3.2 contains the liveness fix (ballerina-platform/module-ballerinax-cdc#39): `isLive()` now short-circuits on the synchronously-set `IS_STARTED` flag, so a listener reports as not-live **immediately** after `gracefulStop()`/`immediateStop()`, instead of racing on the asynchronous Debezium completion callback. This resolves intermittent failures of `testLivenessAfterListenerStop`.

## Changes

- `gradle.properties`: `stdlibCdcVersion` `1.3.0` → `1.3.2`
- `ballerina/Dependencies.toml`: cdc `1.3.0` → `1.3.2` (regenerated by the build)
- The accompanying `[Automated] Update the native jar versions` commit (toml/jar-version sync) is the standard build-generated update.

## Checks

- [x] `./gradlew clean build -x test` passes locally
- [ ] Full test suite (draft — CI to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request updates the `ballerinax/cdc` dependency from `1.3.0` to `1.3.2` for the MSSQL module to improve the stability of CDC listener shutdown behavior and reduce intermittent liveness-related test failures. The update adjusts liveness detection to reliably reflect the listener state immediately after stop operations.

## Changes

- **gradle.properties**: Bumped `stdlibCdcVersion` from `1.3.0` to `1.3.2`
- **ballerina/Dependencies.toml**: Regenerated to reflect the updated `ballerinax:cdc` version
- **ballerina/Ballerina.toml**: Updated MSSQL package metadata and the native `mssql-native` snapshot jar reference to `1.18.1-SNAPSHOT`
- **ballerina/CompilerPlugin.toml**: Updated `mssql-compiler-plugin` snapshot jar reference to `1.18.1-SNAPSHOT`

## Verification

- Confirmed locally: `./gradlew clean build -x test` completes successfully. Full CI test execution remains pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->