### PR TITLE
Fix onError count assertion in testCdcListenerEvents

### DIFF
--- a/ballerina/tests/listener_tests.bal
+++ b/ballerina/tests/listener_tests.bal
@@ -252,8 +252,8 @@ function testCdcListenerEvents() returns error? {
         `INSERT INTO vendors (id, name, contact_info) 
         VALUES (201, 'Vendor A', 'contact@vendora.com')`);
     runtime:sleep(sleepBetweenSteps);
-    test:assertEquals(onErrorCount, 3, msg = "Error count mismatch.");
-    // 1,2 for onRead method not present, 3 for payload binding failure
+    test:assertEquals(onErrorCount, 1, msg = "Error count mismatch.");
+    // 1 for payload binding failure; missing 'onRead' no longer triggers 'onError' (logged as a warning) since cdc 1.3.2
 
     check testListener.gracefulStop();
 }


### PR DESCRIPTION
## Purpose

Fixes the `testCdcListenerEvents` failure introduced by the cdc `1.3.0` → `1.3.2` bump (#1187):

```
[fail] testCdcListenerEvents:
    error {ballerina/test:0}TestError ("Error count mismatch.
    expected: '3'
    actual    : '1'")
```

## Root cause

cdc `1.3.2` includes [`Convert no function error to a warning`](https://github.com/ballerina-platform/module-ballerinax-cdc/commit/5195fb598c9cf2815316000e4aa65ff04754e919). Previously a missing service method (e.g. `onRead`) threw an event-processing error that was routed to `onError`. Now it is logged as a warning and the record is marked processed — `onError` is **not** invoked.

`mssqlDataBindingFailService` (attached to `vendors`, which has no `onRead`) therefore no longer fires `onError` for the two snapshot-read rows. Only the payload-binding failure on the `vendors` INSERT fires `onError`, so the expected count is **1**, not **3**.

## Changes

- Update the `onErrorCount` assertion from `3` to `1` and refresh the explanatory comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes a test failure in `testCdcListenerEvents` that occurred following an upgrade of the CDC library from version 1.3.0 to 1.3.2.

### Root Cause
The CDC library version 1.3.2 introduced a behavioral change in how missing service methods are handled. Previously, when a service method was absent (such as `onRead`), the module would generate an event-processing error routed to the `onError` handler. In version 1.3.2, this behavior changed: missing service methods are now logged as warnings with the record marked as processed, without invoking the error handler.

### Changes Made
The test assertion for `onErrorCount` in the `vendors` table operation has been adjusted from 3 to 1, reflecting the new CDC behavior. The accompanying comment has been updated to clarify that only payload binding failures during INSERT operations trigger `onError`, while missing service methods no longer result in error invocations.

### Impact
- Improves test reliability by aligning expectations with the actual behavior of the updated CDC library
- Maintains test coverage of relevant error scenarios while accounting for library-level behavioral changes
- No changes to public API or exported functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->