### PR TITLE
Upgrade bundled Debezium dependencies to 3.5.1.Final

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "mssql"
-version = "1.18.1"
+version = "1.19.0"
 authors = ["Ballerina"]
 keywords = ["Client", "Network", "SQL", "RDBMS", "SQLServer", "MSSQL", "Vendor/Microsoft", "Area/Database", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-mssql"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "mssql-native"
-version = "1.18.1"
-path = "../native/build/libs/mssql-native-1.18.1-SNAPSHOT.jar"
+version = "1.19.0"
+path = "../native/build/libs/mssql-native-1.19.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "mssql-compiler-plugin"
 class = "io.ballerina.stdlib.mssql.compiler.MSSQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/mssql-compiler-plugin-1.18.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/mssql-compiler-plugin-1.19.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -80,7 +80,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.4"
+version = "2.16.5"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.10.1"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -80,7 +80,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.0"
+version = "2.16.4"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -317,7 +317,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -342,7 +342,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -353,7 +353,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -405,7 +405,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -421,7 +421,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mssql"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -443,7 +443,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mssql.cdc.driver"
-version = "1.0.2"
+version = "1.1.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerinax", name = "mssql.driver"}

--- a/ballerina/tests/resources/compose.yaml
+++ b/ballerina/tests/resources/compose.yaml
@@ -1,3 +1,4 @@
+name: ballerinax-mssql-tests
 services:
     mssql:
         image: mcr.microsoft.com/mssql/server:2019-latest

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgrade CDC dependencies to the Debezium 3.5.1-compatible release line.
+
 ## [1.18.0] - 2026-04-01
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ spotbugsPluginVersion=6.0.18
 downloadPluginVersion=5.4.0
 shadowJarPluginVersion=8.1.1
 releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=2.3.1
 
 msSQLDriverVersion=12.8.1.jre11
 testngVersion=7.6.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.stdlib
-version=1.18.1-SNAPSHOT
+version=1.19.0-SNAPSHOT
 ballerinaLangVersion=2201.13.0
 
 checkstylePluginVersion=10.12.1
@@ -30,8 +30,8 @@ stdlibFileVersion=1.12.0
 observeVersion=1.7.1
 observeInternalVersion=1.5.0
 
-stdlibCdcVersion=1.3.2
-stdlibMSSQLCdcDriverVersion=1.0.2
+stdlibCdcVersion=1.4.0
+stdlibMSSQLCdcDriverVersion=1.1.0
 
 # Transitive Dependencies
 # Level 01


### PR DESCRIPTION
## Purpose

Upgrade the CDC dependencies consumed by this module (`ballerinax/cdc`, `ballerinax/mssql.cdc.driver`) to the Debezium 3.5.1.Final-compatible release line.

This module's own code is unchanged; only the dependency versions in `gradle.properties` are bumped. Verified locally against the bumped `cdc` (1.4.0) and `mssql.cdc.driver` (1.1.0) via `bal push --repository=local` — full `./gradlew build` passes (139/139 tests, including `testCdcListenerEvents`, `testDetachAfterStart`, `testAttachAfterStart`).

Also fixed a docker-compose project-name collision (`ballerina/tests/resources/compose.yaml` now sets an explicit `name:`) so this module's test containers don't collide with other CDC connector repos' test containers when run back-to-back on the same machine.

**Note:** this PR depends on [ballerinax/cdc#42](https://github.com/ballerina-platform/module-ballerinax-cdc/pull/42) and [ballerinax/mssql.cdc.driver#8](https://github.com/ballerina-platform/module-ballerinax-mssql.cdc.driver/pull/8) being merged and released first — until then, `stdlibCdcVersion`/`stdlibMSSQLCdcDriverVersion` in `gradle.properties` won't resolve for anyone building from a fresh checkout, since there are intentionally no local/override pins masking that.

## Checklist

- [x] Read the [contributing guidelines](https://github.com/ballerina-platform/ballerina-standard-library/blob/main/docs/contributing-guidelines.md)
- [x] Updated the [change log](changelog.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Upgraded the project and MSSQL package versions to `1.19.0`.
- Updated Ballerina dependencies, including `ballerinax/cdc` `1.4.0` and `ballerinax/mssql.cdc.driver` `1.1.0`, for Debezium 3.5.1 compatibility.
- Upgraded the Ballerina Gradle plugin to `2.3.1`.
- Added an explicit Docker Compose project name to prevent test-container name collisions.
- Documented the dependency updates in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->